### PR TITLE
Fix TypeScript error for unknown 'pageId' property

### DIFF
--- a/agent/llm_service.py
+++ b/agent/llm_service.py
@@ -515,6 +515,7 @@ def get_dynamic_page_code(blueprint: SiteBlueprint, component_filenames: List[st
     }}
 
     interface Page {{
+      page_id: string;
       page_name: string;
       page_path: string;
       sections: Section[];


### PR DESCRIPTION
This commit fixes a TypeScript compilation error that occurred because the `Page` interface was missing the `pageId` property.

The following changes were made:
- The `Page` interface in the prompt for the `get_dynamic_page_code` function in `agent/llm_service.py` has been updated to include the `pageId` field.