### PR TITLE
fix: Update TypeScript definitions in prompt

### DIFF
--- a/agent/llm_service.py
+++ b/agent/llm_service.py
@@ -522,23 +522,24 @@ def get_dynamic_page_code(blueprint: SiteBlueprint, component_filenames: List[st
     **TypeScript Type Definitions (for context):**
     You MUST use these interfaces to correctly type variables derived from the blueprint.
     ```tsx
-    interface Component {{
+    interface Component {
       component_name: string;
-      props: Record<string, unknown>; // Use 'unknown' instead of 'any' for props
-    }}
+      props: Record<string, unknown>;
+    }
 
-    interface Section {{
+    interface Section {
       section_name: string;
       heading: string | null;
       components: Component[];
-    }}
+    }
 
-    interface Page {{
-      page_id: string;
-      page_name: string;
-      page_path: string;
+    // THIS MUST EXACTLY MATCH THE PYTHON SCHEMA
+    interface Page {
+      id: string;
+      name: string; // Use 'name' for the page title
+      path: string; // Use 'path' for the URL slug
       sections: Section[];
-    }}
+    }
     ```
 
     **CRITICAL NEXT.JS 15 REQUIREMENTS:**


### PR DESCRIPTION
This commit updates the TypeScript type definitions within the prompt for the `get_dynamic_page_code` function in `agent/llm_service.py`.

The `Page` interface in the prompt was outdated and did not match the Python `SiteBlueprint` schema. The interface has been updated to use `id`, `name`, and `path` instead of `page_id`, `page_name`, and `page_path`.

This change ensures that the AI generating the dynamic page component has the correct type information, preventing potential inconsistencies between the generated code and the data structure it consumes.