### PR TITLE
fix: Escape curly braces in llm_service prompt

### DIFF
--- a/agent/llm_service.py
+++ b/agent/llm_service.py
@@ -522,24 +522,24 @@ def get_dynamic_page_code(blueprint: SiteBlueprint, component_filenames: List[st
     **TypeScript Type Definitions (for context):**
     You MUST use these interfaces to correctly type variables derived from the blueprint.
     ```tsx
-    interface Component {
+    interface Component {{
       component_name: string;
       props: Record<string, unknown>;
-    }
+    }}
 
-    interface Section {
+    interface Section {{
       section_name: string;
       heading: string | null;
       components: Component[];
-    }
+    }}
 
     // THIS MUST EXACTLY MATCH THE PYTHON SCHEMA
-    interface Page {
+    interface Page {{
       id: string;
       name: string; // Use 'name' for the page title
       path: string; // Use 'path' for the URL slug
       sections: Section[];
-    }
+    }}
     ```
 
     **CRITICAL NEXT.JS 15 REQUIREMENTS:**


### PR DESCRIPTION
This commit fixes a `NameError` that occurred during the generation of the dynamic page component.

The error was caused by unescaped curly braces in the TypeScript type definitions within the f-string prompt in the `get_dynamic_page_code` function of `agent/llm_service.py`. The Python f-string formatter was incorrectly trying to evaluate the content inside the braces as expressions.

The fix involves escaping all the curly braces in the TypeScript interface definitions by doubling them (e.g., `{` becomes `{{`), which prevents them from being interpreted by the f-string formatter.