### PR TITLE
fix: Use page.name instead of page.page_name

### DIFF
--- a/agent/llm_service.py
+++ b/agent/llm_service.py
@@ -459,7 +459,7 @@ def get_tailwind_config_code(blueprint: SiteBlueprint, task_id: str) -> str:
     return _generate_code(prompt, "tailwind.config.ts", task_id)
 
 def get_header_code(blueprint: SiteBlueprint, task_id: str) -> str:
-    page_links = ", ".join([f"'{page.page_name}'" for page in blueprint.pages])
+    page_links = ", ".join([f"'{page.name}'" for page in blueprint.pages])
     client = blueprint.client_name
     prompt = f"""
     Generate a `Header.tsx` component for a Next.js project.
@@ -481,7 +481,7 @@ def get_header_code(blueprint: SiteBlueprint, task_id: str) -> str:
     return _generate_code(prompt, "Header.tsx", task_id)
 
 def get_footer_code(blueprint: SiteBlueprint, task_id: str) -> str:
-    page_links = ", ".join([f"'{page.page_name}'" for page in blueprint.pages])
+    page_links = ", ".join([f"'{page.name}'" for page in blueprint.pages])
     client = blueprint.client_name
     prompt = f"""
     Generate a `Footer.tsx` component for a Next.js project.


### PR DESCRIPTION
This commit fixes an `AttributeError` that occurred in `agent/llm_service.py`.

The error was caused by the code in `get_header_code` and `get_footer_code` trying to access the `page_name` attribute on a `Page` object, which was recently refactored to use `name` instead.

This change updates the list comprehensions in both functions to use `page.name`, aligning the code with the updated `Page` schema and resolving the `AttributeError`.