### PR TITLE
refactor: Remove retry loop for a single targeted repair attempt

### DIFF
--- a/agent/deployer.py
+++ b/agent/deployer.py
@@ -221,37 +221,30 @@ module.exports = nextConfig;
                 DeployerLogger.log_warning("build.duplicate_lockfile", f"Removing duplicate lockfile at {duplicate_lockfile}")
                 duplicate_lockfile.unlink()
 
-            build_successful = False
-            for i in range(3): # 3-strike build attempts
-                attempt_num = i + 1
-                DeployerLogger.log_info("build.attempt", f"Build attempt {attempt_num}...")
+            # First build attempt
+            build_result = run(["pnpm", "run", "build"], cwd=str(site_path), task_id=task_id)
+            DeployerLogger.log_command_result(build_result, "next_build_attempt_1")
 
-                build_result = run(["pnpm", "run", "build"], cwd=str(site_path), task_id=task_id)
-                DeployerLogger.log_command_result(build_result, f"next_build_attempt_{attempt_num}")
+            if not build_result.success:
+                DeployerLogger.log_warning("build.failed", "Initial build failed. Attempting one targeted error correction.")
 
-                if build_result.success:
-                    build_successful = True
-                    DeployerLogger.log_info("build.success", f"Build attempt {attempt_num} successful.")
-                    break # Exit the loop on successful build
-
-                # If build failed, attempt to fix it
-                DeployerLogger.log_warning("build.failed", f"Build attempt {attempt_num} failed. Attempting targeted error correction.")
                 error_details = parse_build_error(build_result.stderr)
-
-                if not error_details:
-                    DeployerLogger.log_error("build.parse.failed", "Could not parse build error. Halting.")
+                if error_details:
+                    fix_successful = attempt_targeted_fix(site_path, error_details, task_id)
+                    if fix_successful:
+                        DeployerLogger.log_info("build.fix.success", "Targeted fix applied successfully. Retrying build.")
+                        # Second and final build attempt
+                        build_result = run(["pnpm", "run", "build"], cwd=str(site_path), task_id=task_id)
+                        DeployerLogger.log_command_result(build_result, "next_build_attempt_2")
+                        if not build_result.success:
+                            DeployerLogger.log_error("build.failed_after_fix", "Build failed again after applying targeted fix.")
+                            raise Exception("Failed to build Next.js project after targeted fix.")
+                    else:
+                        DeployerLogger.log_error("build.fix.failed", "Targeted fix attempt failed. Unable to correct build error.")
+                        raise Exception("Failed to apply targeted fix to build error.")
+                else:
+                    DeployerLogger.log_error("build.parse.failed", "Could not parse build error. Unable to attempt targeted fix.")
                     raise Exception("Failed to build Next.js project and could not parse error log.")
-
-                fix_successful = attempt_targeted_fix(site_path, error_details, task_id)
-                if not fix_successful:
-                    DeployerLogger.log_error("build.fix.failed", "Targeted fix attempt failed. Halting.")
-                    raise Exception("Failed to apply targeted fix to build error.")
-
-                DeployerLogger.log_info("build.fix.success", f"Targeted fix applied for attempt {attempt_num}. Retrying build...")
-
-            if not build_successful:
-                DeployerLogger.log_error("build.failed_after_retries", "Build failed after 3 attempts.")
-                raise Exception("Failed to build Next.js project after multiple targeted fix attempts.")
 
             DeployerLogger.log_resource_usage("after_build")
 


### PR DESCRIPTION
This commit refactors the `build_and_deploy` function in `agent/deployer.py` to remove the 3-strike retry loop and implement a more direct, single-attempt repair process as per the user's latest request.

The new workflow is:
1.  Attempt to build the project.
2.  If the build fails, attempt a single targeted repair.
3.  If the repair is successful, attempt to build one more time.
4.  If the second build fails, or if the repair fails, the process halts.

This change simplifies the logic and prevents multiple repair attempts, making the process faster and more direct.

---
feat: Implement Build, Targeted-Repair, and Retry pipeline

This commit implements a new, highly efficient "Build-First" workflow for the AI website generator, replacing the previous proactive critic pipeline with a reactive, build-first approach.

The new "Build, Targeted-Repair, and Retry" pipeline works as follows:
1.  **Bulk Generation:** All code is generated in a single pass without any pre-build analysis, significantly speeding up the initial step.
2.  **Build-Triage-Repair Loop:** The system attempts to build the project up to three times.
    - If a build fails, the error log is parsed to identify the exact file and line number of the first critical error.
    - A targeted call is made to the generator AI to fix only that specific error.
    - The fix is applied, and the build is retried.
3.  **Deployment:** If any of the build attempts are successful, the system proceeds to deployment. If all three attempts fail, the task is marked as failed.

This new architecture makes the system much faster and more cost-effective by reserving AI-powered repair for when it's proven to be necessary.

Key changes:
- Refactored `agent/deployer.py` to include the 3-strike build-and-retry loop.
- Created `agent/error_handler.py` to handle parsing of build logs and orchestration of targeted fixes.
- Simplified `agent/llm_service.py` and `agent/enhanced_llm_service.py` to remove the pre-build critic pipeline.
- Ensured `tasks.py` is streamlined for the new workflow.